### PR TITLE
Typo fixed in OpenID PKCE auth flow

### DIFF
--- a/oidc-sso-tutorials/tutorials/Why-OpenID-Connect-OAuth-2.0-Authorization-Code-PKCE-Flow-for-SPA.md
+++ b/oidc-sso-tutorials/tutorials/Why-OpenID-Connect-OAuth-2.0-Authorization-Code-PKCE-Flow-for-SPA.md
@@ -73,7 +73,7 @@ In this case, the **/token** endpoint is not protected by [**Token Endpoint auth
 
 3. OP Server authenticates the user and redirects back to `https://client.com/callback` with code in URL. You can check the above flow diagram.
 
-4. Now request to **https://your_op_server.com/token** with **code** and **code_challenge**.
+4. Now request to **https://your_op_server.com/token** with **code** and **code_verifier**.
 
     ```sh
     HTTP POST https://your_op_server.com/token


### PR DESCRIPTION
Corrected incorrect reference to `code_challenge` to correct reference `code_verifier` in PKCE auth flow challenge response request.